### PR TITLE
Add feature(i128_type) to silence errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(i128_type)]
+
 #![allow(unused_imports)]
 
 extern crate byteorder;


### PR DESCRIPTION
Without this I get a long list of errors like:
```
error[E0658]: 128-bit type is unstable (see issue #35118)
   --> src/lib.rs:367:35
    |
367 |         let tmp = (1u128 << 64) + u128::from(a) - u128::from(b) - u128::from(*borrow);
    |                                   ^^^^^^^^^^
    |
    = help: add #![feature(i128_type)] to the crate attributes to enable

error[E0658]: 128-bit type is unstable (see issue #35118)
   --> src/lib.rs:367:51
    |
367 |         let tmp = (1u128 << 64) + u128::from(a) - u128::from(b) - u128::from(*borrow);
    |                                                   ^^^^^^^^^^
    |
    = help: add #![feature(i128_type)] to the crate attributes to enable
```

If this is merged, I'd also be grateful to have this released and https://github.com/zkcrypto/pairing/ be bumped to use this fix.

I'm working on https://github.com/JacobEberhardt/ZoKrates/issues/90 which requires the pairing library to be compiled to webassembly.