### PR TITLE
enabling `zeroize` for field elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Library for building and interfacing with finite fields"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 byteorder = "1"
 ff_derive = { version = "0.4.0", path = "ff_derive", optional = true }
 rand_core = "0.5"
+zeroize = {version = "1.1", features = ["zeroize_derive"]}
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ff-zeroize"
+name = "ff"
 version = "0.6.3"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Library for building and interfacing with finite fields"
@@ -12,13 +12,13 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1"
-ff_derive-zeroize = { version = "0.6.2", path = "ff_derive", optional = true }
+ff_derive = { version = "0.6.2", path = "ff_derive", optional = true }
 rand_core = "0.5"
 zeroize = {version = "1.1", features = ["zeroize_derive"]}
 
 [features]
 default = []
-derive = ["ff_derive-zeroize"]
+derive = ["ff_derive"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-zeroize"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Library for building and interfacing with finite fields"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ff-zeroize"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Library for building and interfacing with finite fields"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1"
-ff_derive = { version = "0.4.0", path = "ff_derive", optional = true }
+ff_derive-zeroize = { version = "0.6.2", path = "ff_derive", optional = true }
 rand_core = "0.5"
 zeroize = {version = "1.1", features = ["zeroize_derive"]}
 
 [features]
 default = []
-derive = ["ff_derive"]
+derive = ["ff_derive-zeroize"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the `ff` crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ff = "0.4"
+ff = "0.5"
 ```
 
 The `ff` crate contains `Field`, `PrimeField`, `PrimeFieldRepr` and `SqrtField` traits.

--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ff_derive-zeroize"
+name = "ff_derive"
 version = "0.6.2"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Procedural macro library used to build custom prime field implementations"

--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "ff_derive"
-version = "0.4.0"
+name = "ff_derive-zeroize"
+version = "0.6.2"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "Procedural macro library used to build custom prime field implementations"
 documentation = "https://docs.rs/ff/"

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -116,7 +116,7 @@ fn fetch_attr(name: &str, attrs: &[syn::Attribute]) -> Option<String> {
 // Implement PrimeFieldRepr for the wrapped ident `repr` with `limbs` limbs.
 fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenStream {
     quote! {
-        #[derive(Copy, Clone, PartialEq, Eq, Default)]
+        #[derive(Copy, Clone, PartialEq, Eq, Default, Zeroize)]
         pub struct #repr(pub [u64; #limbs]);
 
         impl ::std::fmt::Debug for #repr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,10 @@ use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
-use zeroize::Zeroize;
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + Zeroize
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
@@ -112,7 +111,6 @@ pub trait PrimeFieldRepr:
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>
-    + Zeroize
 {
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "derive")]
 #[macro_use]
-extern crate ff_derive;
+extern crate ff_derive-zeroize as ff_derive;
 
 #[cfg(feature = "derive")]
 pub use ff_derive::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,18 @@ extern crate ff_derive;
 #[cfg(feature = "derive")]
 pub use ff_derive::*;
 
+#[macro_use]
+extern crate zeroize;
+
 use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
+use zeroize::Zeroize;
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + Zeroize
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
@@ -108,6 +112,7 @@ pub trait PrimeFieldRepr:
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>
+    + Zeroize
 {
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "derive")]
 #[macro_use]
-extern crate ff_derive_zeroize as ff_derive;
+extern crate ff_derive;
 
 #[cfg(feature = "derive")]
 pub use ff_derive::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub trait PrimeFieldRepr:
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>
+    + zeroize::Zeroize
 {
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "derive")]
 #[macro_use]
-extern crate ff_derive-zeroize as ff_derive;
+extern crate ff_derive_zeroize as ff_derive;
 
 #[cfg(feature = "derive")]
 pub use ff_derive::*;


### PR DESCRIPTION
This PR enables `zeroize` for field elements -- allows for better memory safety for upper layer libs such as pairing or bls signatures. Would love to see this functionality merged to the main repo.