### PR TITLE
enabling `zeroize` for field elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 byteorder = "1"
 ff_derive = { version = "0.4.0", path = "ff_derive", optional = true }
 rand_core = "0.5"
+zeroize = {version = "1.1", features = ["zeroize_derive"]}
 
 [features]
 default = []

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -116,7 +116,7 @@ fn fetch_attr(name: &str, attrs: &[syn::Attribute]) -> Option<String> {
 // Implement PrimeFieldRepr for the wrapped ident `repr` with `limbs` limbs.
 fn prime_field_repr_impl(repr: &syn::Ident, limbs: usize) -> proc_macro2::TokenStream {
     quote! {
-        #[derive(Copy, Clone, PartialEq, Eq, Default)]
+        #[derive(Copy, Clone, PartialEq, Eq, Default, Zeroize)]
         pub struct #repr(pub [u64; #limbs]);
 
         impl ::std::fmt::Debug for #repr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,10 @@ use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
-use zeroize::Zeroize;
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + Zeroize
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
@@ -112,7 +111,6 @@ pub trait PrimeFieldRepr:
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>
-    + Zeroize
 {
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,18 @@ extern crate ff_derive;
 #[cfg(feature = "derive")]
 pub use ff_derive::*;
 
+#[macro_use]
+extern crate zeroize;
+
 use rand_core::RngCore;
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Read, Write};
+use zeroize::Zeroize;
 
 /// This trait represents an element of a field.
 pub trait Field:
-    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static
+    Sized + Eq + Copy + Clone + Send + Sync + fmt::Debug + fmt::Display + 'static + Zeroize
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: RngCore + ?std::marker::Sized>(rng: &mut R) -> Self;
@@ -108,6 +112,7 @@ pub trait PrimeFieldRepr:
     + AsRef<[u64]>
     + AsMut<[u64]>
     + From<u64>
+    + Zeroize
 {
     /// Subtract another represetation from this one.
     fn sub_noborrow(&mut self, other: &Self);


### PR DESCRIPTION
This PR enables zeroize for field elements -- allows for better memory safety for upper layer libs such as pairing or bls signatures. Would love to see this functionality merged to the main repo.

Replacing PR https://github.com/zkcrypto/ff/pull/22