### PR TITLE
Upgrades num-bigint to 0.3

### DIFF
--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-num-bigint = "0.2"
+num-bigint = "0.3"
 num-traits = "0.2"
 num-integer = "0.1"
 proc-macro2 = "1"

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -314,7 +314,7 @@ fn biguint_to_real_u64_vec(mut v: BigUint, limbs: usize) -> Vec<u64> {
     let mut ret = vec![];
 
     while v > BigUint::zero() {
-        ret.push((&v % &m).to_u64().unwrap());
+        ret.push(((&v % &m) as BigUint).to_u64().unwrap());
         v = v >> 64;
     }
 


### PR DESCRIPTION
`num_bigint v0.3` was released on June 12th and I suggest to upgrade its version for compatibility with other libraries. 

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>