### PR TITLE
Switch to Field::random(rng: impl RngCore) -> Self

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1204,7 +1204,7 @@ fn prime_field_impl(
 
         impl ::ff::Field for #name {
             /// Computes a uniformly random element using rejection sampling.
-            fn random<R: ::rand_core::RngCore + ?Sized>(rng: &mut R) -> Self {
+            fn random(mut rng: impl ::rand_core::RngCore) -> Self {
                 loop {
                     let mut tmp = {
                         let mut repr = [0u64; #limbs];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub trait Field:
     + for<'a> SubAssign<&'a Self>
 {
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
+    fn random(rng: impl RngCore) -> Self;
 
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self;


### PR DESCRIPTION
This aligns the ff::Field::random API with the group::Group::random API.