### PR TITLE
Add `#![forbid(unsafe_code)] attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(unused_imports)]
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "std")]
 #[macro_use]


### PR DESCRIPTION
This crate's one liner is "`ff` is a finite field library written in pure Rust, with no `unsafe{}` code."

This attribute commits to that.