### PR TITLE
Add `bits` feature; factor out PrimeFieldBits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           command: build
           args: --verbose --target thumbv6m-none-eabi --no-default-features
+      - name: Build with bits feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --target thumbv6m-none-eabi --no-default-features --features bits
 
   doc-links:
     name: Nightly lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,15 @@ repository = "https://github.com/ebfull/ff"
 edition = "2018"
 
 [dependencies]
-bitvec = { version = "0.20.0", default-features = false }
+bitvec = { version = "0.20.0", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false, optional = true }
 ff_derive = { version = "0.8", path = "ff_derive", optional = true }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.2.1", default-features = false, features = ["i128"] }
 
 [features]
-default = ["std"]
+default = ["bits", "std"]
+bits = ["bitvec"]
 derive = ["byteorder", "ff_derive"]
 std = []
 
@@ -31,3 +32,7 @@ required-features = ["derive"]
 
 [badges]
 maintenance = { status = "actively-developed" }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -116,6 +116,7 @@ impl ReprEndianness {
     }
 }
 
+/// Derive the `PrimeField` trait.
 #[proc_macro_derive(
     PrimeField,
     attributes(PrimeFieldModulus, PrimeFieldGenerator, PrimeFieldReprEndianness)
@@ -1141,7 +1142,6 @@ fn prime_field_impl(
 
         impl ::ff::PrimeField for #name {
             type Repr = #repr;
-            type ReprBits = REPR_BITS;
 
             fn from_repr(r: #repr) -> Option<#name> {
                 #from_repr_impl
@@ -1149,10 +1149,6 @@ fn prime_field_impl(
 
             fn to_repr(&self) -> #repr {
                 #to_repr_impl
-            }
-
-            fn to_le_bits(&self) -> ::bitvec::array::BitArray<::bitvec::order::Lsb0, REPR_BITS> {
-                #to_le_bits_impl
             }
 
             #[inline(always)]
@@ -1163,10 +1159,6 @@ fn prime_field_impl(
                 );
 
                 r.0[0] & 1 == 1
-            }
-
-            fn char_le_bits() -> ::bitvec::array::BitArray<::bitvec::order::Lsb0, REPR_BITS> {
-                ::bitvec::array::BitArray::new(MODULUS)
             }
 
             const NUM_BITS: u32 = MODULUS_BITS;
@@ -1181,6 +1173,18 @@ fn prime_field_impl(
 
             fn root_of_unity() -> Self {
                 ROOT_OF_UNITY
+            }
+        }
+
+        impl ::ff::PrimeFieldBits for #name {
+            type ReprBits = REPR_BITS;
+
+            fn to_le_bits(&self) -> ::ff::FieldBits<REPR_BITS> {
+                #to_le_bits_impl
+            }
+
+            fn char_le_bits() -> ::ff::FieldBits<REPR_BITS> {
+                ::ff::FieldBits::new(MODULUS)
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 // Catch documentation errors caused by code changes.
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(intra_doc_link_resolution_failure)]
 #![allow(unused_imports)]
 #![forbid(unsafe_code)]
@@ -11,10 +12,14 @@
 extern crate std;
 
 #[cfg(feature = "derive")]
-pub use ff_derive::*;
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub use ff_derive::PrimeField;
 
+#[cfg(feature = "bits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub use bitvec::view::BitView;
 
+#[cfg(feature = "bits")]
 use bitvec::{array::BitArray, order::Lsb0};
 use core::convert::TryFrom;
 use core::fmt;
@@ -26,6 +31,8 @@ use std::io::{self, Read, Write};
 use subtle::{ConditionallySelectable, CtOption};
 
 /// Bit representation of a field element.
+#[cfg(feature = "bits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
 pub type FieldBits<V> = BitArray<Lsb0, V>;
 
 /// This trait represents an element of a field.
@@ -115,9 +122,6 @@ pub trait PrimeField: Field + From<u64> {
     /// representation.
     type Repr: Default + AsRef<[u8]> + AsMut<[u8]>;
 
-    /// The backing store for a bit representation of a prime field element.
-    type ReprBits: BitView + Send + Sync;
-
     /// Interpret a string of numbers as a (congruent) prime field element.
     /// Does not accept unnecessary leading zeroes or a blank string.
     fn from_str(s: &str) -> Option<Self> {
@@ -173,9 +177,6 @@ pub trait PrimeField: Field + From<u64> {
     /// encodings of field elements should be treated as opaque.
     fn to_repr(&self) -> Self::Repr;
 
-    /// Converts an element of the prime field into a little-endian sequence of bits.
-    fn to_le_bits(&self) -> FieldBits<Self::ReprBits>;
-
     /// Returns true iff this element is odd.
     fn is_odd(&self) -> bool;
 
@@ -184,9 +185,6 @@ pub trait PrimeField: Field + From<u64> {
     fn is_even(&self) -> bool {
         !self.is_odd()
     }
-
-    /// Returns the bits of the field characteristic (the modulus) in little-endian order.
-    fn char_le_bits() -> FieldBits<Self::ReprBits>;
 
     /// How many bits are needed to represent an element of this field.
     const NUM_BITS: u32;
@@ -218,6 +216,20 @@ pub trait PrimeField: Field + From<u64> {
     /// It can be calculated by exponentiating `Self::multiplicative_generator` by `t`,
     /// where `t = (modulus - 1) >> Self::S`.
     fn root_of_unity() -> Self;
+}
+
+/// This represents the bits of an element of a prime field.
+#[cfg(feature = "bits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bits")))]
+pub trait PrimeFieldBits: PrimeField {
+    /// The backing store for a bit representation of a prime field element.
+    type ReprBits: BitView + Send + Sync;
+
+    /// Converts an element of the prime field into a little-endian sequence of bits.
+    fn to_le_bits(&self) -> FieldBits<Self::ReprBits>;
+
+    /// Returns the bits of the field characteristic (the modulus) in little-endian order.
+    fn char_le_bits() -> FieldBits<Self::ReprBits>;
 }
 
 pub use self::arith_impl::*;


### PR DESCRIPTION
(NOTE: breaking change)

Makes `bitvec` an optional dependency by factoring the types and methods which depend on it into their own trait - `PrimeFieldBits`.