### PR TITLE
Remove From<Self> bounds on PrimeField::Repr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub trait Field:
 pub trait PrimeField: Field + From<u64> {
     /// The prime field can be converted back and forth into this binary
     /// representation.
-    type Repr: Default + AsRef<[u8]> + AsMut<[u8]> + From<Self> + for<'r> From<&'r Self>;
+    type Repr: Default + AsRef<[u8]> + AsMut<[u8]>;
 
     /// The backing store for a bit representation of a prime field element.
     type ReprBits: BitView + Send + Sync;


### PR DESCRIPTION
Removes the `From<Self>` and `From<&Self>` bounds on `PrimeField::Repr`, since both conversions are still possible via the `PrimeField::to_repr` method.

Motivation: I'm writing code which is generic over elliptic curves, but uses the same (generic) type as `PrimeField::Repr`.

Unfortunately I'm getting a bit hung up on this bound. I can't write an associated type with a `PrimeField::Repr` bound like:

```rust
type Scalar: ff::PrimeField<Repr = FieldBytes>
```

...without including a "viral" where bound like:

```rust
where FieldBytes: From<C::Scalar> + for<'r> From<&'r C::Scalar>
```

...in the case where I'm using a type I haven't defined myself (`FieldBytes` is a type alias for a byte array).

~~I could try make `FieldBytes` into a newtype rather than a type alias, and then add generic implementations of `From` that look like this:~~

```rust
impl<F> From<F> for FieldBytes
where
    F: PrimeField<Repr = FieldBytes>
{
    fn from(field: F) -> FieldBytes {
       field.to_repr()
    }
}
```

(sidebar: ~~that may have a circular trait dependency even!~~ EDIT: worse than that, it conflicts with the blanket impl of `From<T> for T` so it's a complete no-go)

...but really it seems like the `PrimeField::to_repr` method accomplishes the same things as the `From` bounds, so if it's possible to get rid of them and use `to_repr` instead, that would be immensely helpful to me.

Another problem with `From` bounds is they aren't satisfied by `Into`. Otherwise something like this could work:

```rust
type Scalar: ff::PrimeField<Repr = FieldBytes> + Into<FieldBytes>
```

Per the `Into` docs:

https://doc.rust-lang.org/std/convert/trait.Into.html

> Prefer using `Into` over `From` when specifying trait bounds on a generic function to ensure that types that only implement Into can be used as well.

...but this is also an annoying place to use an `Into` bound.