### PR TITLE
Update to bitvec 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ebfull/ff"
 edition = "2018"
 
 [dependencies]
-bitvec = { version = "0.20.0", default-features = false }
+bitvec = { version = "0.21.0", default-features = false }
 byteorder = { version = "1", default-features = false, optional = true }
 ff_derive = { version = "0.8", path = "ff_derive", optional = true }
 rand_core = { version = "0.6", default-features = false }


### PR DESCRIPTION
Note: This is a breaking change because this crate re-exports types from
bitvec.