### PR TITLE
Fix bitvec dep leaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           command: test
           args: --verbose --all-features
+      - name: Run tests (without bitvec)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features --features derive
 
   no-std:
     name: Check no-std compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,22 +77,20 @@ jobs:
           args: --verbose --target thumbv6m-none-eabi --no-default-features --features bits
 
   doc-links:
-    name: Nightly lint
+    name: Documentation
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.51.0
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
           command: fetch
 
-      # Ensure intra-documentation links all resolve correctly
-      # Requires #![deny(intra_doc_link_resolution_failure)] in crate.
       - name: Check intra-doc links
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ alloc = []
 bits = ["bitvec"]
 derive = ["byteorder", "ff_derive"]
 std = ["alloc"]
+# with MSRV 1.60 this could be merged into bits with ff_derive?/bits
+# see PR#72 for more information.
+derive_bits = ["bits", "ff_derive/bits"]
 
 [[test]]
 name = "derive"

--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/zkcrypto/ff"
 edition = "2018"
 
+[features]
+# enabled when generating bitvec code utilizing the version of ff's bitvec
+bits = []
+
 [lib]
 proc-macro = true
 

--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -27,6 +27,7 @@ num-integer = "0.1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }
+cfg-if = "1"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -893,11 +893,35 @@ fn prime_field_impl(
 
     let from_repr_impl = endianness.from_repr(name, limbs);
     let to_repr_impl = endianness.to_repr(quote! {#repr}, &mont_reduce_self_params, limbs);
-    let to_le_bits_impl = ReprEndianness::Little.to_repr(
-        quote! {::ff::derive::bitvec::array::BitArray::new},
-        &mont_reduce_self_params,
-        limbs,
-    );
+
+    let _generate_bitvec_impl = false;
+
+    #[cfg(feature = "bits")]
+    let _generate_bitvec_impl = true;
+
+    let prime_field_bits_impl = if _generate_bitvec_impl {
+        let to_le_bits_impl = ReprEndianness::Little.to_repr(
+            quote! {::ff::derive::bitvec::array::BitArray::new},
+            &mont_reduce_self_params,
+            limbs,
+        );
+
+        quote! {
+            impl ::ff::PrimeFieldBits for #name {
+                type ReprBits = REPR_BITS;
+
+                fn to_le_bits(&self) -> ::ff::FieldBits<REPR_BITS> {
+                    #to_le_bits_impl
+                }
+
+                fn char_le_bits() -> ::ff::FieldBits<REPR_BITS> {
+                    ::ff::FieldBits::new(MODULUS)
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
 
     let top_limb_index = limbs - 1;
 
@@ -1197,17 +1221,7 @@ fn prime_field_impl(
             }
         }
 
-        impl ::ff::PrimeFieldBits for #name {
-            type ReprBits = REPR_BITS;
-
-            fn to_le_bits(&self) -> ::ff::FieldBits<REPR_BITS> {
-                #to_le_bits_impl
-            }
-
-            fn char_le_bits() -> ::ff::FieldBits<REPR_BITS> {
-                ::ff::FieldBits::new(MODULUS)
-            }
-        }
+        #prime_field_bits_impl
 
         impl ::ff::Field for #name {
             /// Computes a uniformly random element using rejection sampling.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,11 @@ pub trait PrimeFieldBits: PrimeField {
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub mod derive {
     pub use crate::arith_impl::*;
-    pub use {bitvec, byteorder, rand_core, subtle};
+
+    pub use {byteorder, rand_core, subtle};
+
+    #[cfg(feature = "bits")]
+    pub use bitvec;
 }
 
 #[cfg(feature = "derive")]

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -60,6 +60,7 @@ fn batch_inversion() {
     }
 
     // Test BatchInvert trait
+    #[cfg(feature = "alloc")]
     {
         use ff::BatchInvert;
         let mut elements = values.clone();


### PR DESCRIPTION
Fixes #69. See comments for the ci change reproducing the issue.

Adds a new feature for ff_derive: `bits`, which controls the code dependent on bitvec on derived output. `ff_derive/bits` is toggled when enabling "derive_bits" on the `ff` crate. The re-exports of `ff` are also adjusted to only contain `bitvec` when `ff/bits` is enabled.