### PR TITLE
fix derive-inside-macro

### DIFF
--- a/ff_derive/Cargo.toml
+++ b/ff_derive/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = "0.2"
 num-integer = "0.1"
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = { version = "1", features = ["full"] }
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -252,11 +252,16 @@ fn validate_struct(ast: &syn::DeriveInput, limbs: usize) -> Option<proc_macro2::
     }
 
     // The array's length should be a literal int equal to `limbs`.
-    let lit_int = match match &arr.len {
-        syn::Expr::Lit(expr_lit) => match &expr_lit.lit {
-            syn::Lit::Int(lit_int) => Some(lit_int),
+    let expr_lit = match &arr.len {
+        syn::Expr::Lit(expr_lit) => Some(&expr_lit.lit),
+        syn::Expr::Group(expr_group) => match &*expr_group.expr {
+            syn::Expr::Lit(expr_lit) => Some(&expr_lit.lit),
             _ => None,
-        },
+        }
+        _ => None
+    };
+    let lit_int = match match expr_lit {
+        Some(syn::Lit::Int(lit_int)) => Some(lit_int),
         _ => None,
     } {
         Some(x) => x,


### PR DESCRIPTION
I ran into this issue when writing a macro to compactly derive a new ff type (and other stuff; this is a minimized example):

```rust
macro_rules! def_field {
    ($name: ident, $mod: literal, $gen: literal, $limbs: literal) => {
        pub mod $name {
            use ff::PrimeField;
            #[derive(PrimeField)]
            #[PrimeFieldModulus = $mod]
            #[PrimeFieldGenerator = $gen]
            #[PrimeFieldReprEndianness = "little"]
            pub struct Ft([u64; $limbs]);
        }
    };
}
```

This fails because the `syn` crate differentiates between `[u64; $limbs]` and `[u64; 4]` (say). The issue is here: https://github.com/zkcrypto/ff/blob/e9eb586251677081ca54537f226c35994951cc02/ff_derive/src/lib.rs#L254-L272

`[u64; 4]` matches the `syn::Expr::Lit(_)` pattern, but `[u64; $limbs]` matches `syn::Expr::Group(expr_group)`, where `expr_group.expr` matches `syn::Expr::Lit(_)`.

This PR fixes, by adding support for `syn::Expr::Group(_)` matching, too.