### PR TITLE
feat: add `GpuName` trait bounds when `gpu` feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 [dependencies]
 bitvec = { version = "1", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false, optional = true }
+ec-gpu = { version = "0.2.0", optional = true }
 ff_derive = { version = "0.12", path = "ff_derive", optional = true }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.2.1", default-features = false, features = ["i128"] }
@@ -29,6 +30,7 @@ std = ["alloc"]
 # with MSRV 1.60 this could be merged into bits with ff_derive?/bits
 # see PR#72 for more information.
 derive_bits = ["bits", "ff_derive/bits"]
+gpu = ["ec-gpu"]
 
 [[test]]
 name = "derive"

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1296,6 +1296,13 @@ fn prime_field_impl(
             }
         }
 
+        #[cfg(feature = "gpu")]
+        impl ec_gpu::GpuName for #name {
+           fn name() -> String {
+               ec_gpu::name!()
+           }
+        }
+
         impl #name {
             /// Compares two elements in native representation. This is only used
             /// internally.


### PR DESCRIPTION
When the `gpu` feature is enabled, the `GpuName` trait from `ec-gpu`
is added to the trait bounds of `Field`.

This makes the trait bounds of projects wanting to support GPUs way
easier. The `Gpu*` traits won't bleed into the whole API. Conditional
trait bounds like this

    impl<
            #[cfg(not(any(feature = "cuda", feature = "opencl")))] F: PrimeField,
            #[cfg(any(feature = "cuda", feature = "opencl"))] F: PrimeField + ec_gpu::GpuName,
            A: Arity<F>,
        > BatchHasher<F, A> for Batcher<F, A>

won't be needed.

I have to say that I'm unsure about whether this change is a good idea or not. I only know that without that change, it is nearly impossible/extremely ugly to get the Halo2 proof system working on the GPU. I'd also be happy to hear about alternative implementations, that's the best I could come up with where things are still kind of easy to follow. But I guess there are better ways, perhaps a derive macro (though that might be a bit much for this case).

So let's focus first on whether this idea of having the `ec_gpu::Name` trait optionally added via feature flag is something that has a chance to get merged and if it is the case, then on the actual implementation.