### PR TITLE
Add associated constants of type `Self` to `Field` and `PrimeField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
+- `ff::Field::{ZERO, ONE}`
 - `ff::Field::pow`
 - `ff::Field::{sqrt_ratio, sqrt_alt}`
+- `ff::PrimeField::{MULTIPLICATIVE_GENERATOR, ROOT_OF_UNITY}`
 - `ff::helpers`:
   - `sqrt_tonelli_shanks`
   - `sqrt_ratio_generic`
@@ -20,6 +22,11 @@ and this library adheres to Rust's notion of
   if it is more efficient in practice, or they can keep their own implementation
   of `Field::sqrt` and implement `Field::sqrt_ratio` in terms of that
   implementation using the `ff::helpers::sqrt_ratio_generic` helper function.
+
+### Removed
+- `ff::Field::{zero, one}` (use `ff::Field::{ZERO, ONE}` instead).
+- `ff::PrimeField::{multiplicative_generator, root_of_unity}` (use
+  `ff::PrimeField::{MULTIPLICATIVE_GENERATOR, ROOT_OF_UNITY}` instead).
 
 ## [0.12.1] - 2022-10-28
 ### Fixed

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -31,19 +31,19 @@ where
     I: IntoIterator<Item = &'a mut F>,
 {
     fn batch_invert(self) -> F {
-        let mut acc = F::one();
+        let mut acc = F::ONE;
         let iter = self.into_iter();
         let mut tmp = alloc::vec::Vec::with_capacity(iter.size_hint().0);
         for p in iter {
             let q = *p;
             tmp.push((acc, p));
-            acc = F::conditional_select(&(acc * q), &acc, q.ct_eq(&F::zero()));
+            acc = F::conditional_select(&(acc * q), &acc, q.is_zero());
         }
         acc = acc.invert().unwrap();
         let allinv = acc;
 
         for (tmp, p) in tmp.into_iter().rev() {
-            let skip = p.ct_eq(&F::zero());
+            let skip = p.is_zero();
 
             let tmp = tmp * acc;
             acc = F::conditional_select(&(acc * *p), &acc, skip);
@@ -74,17 +74,17 @@ impl BatchInverter {
     {
         assert_eq!(elements.len(), scratch_space.len());
 
-        let mut acc = F::one();
+        let mut acc = F::ONE;
         for (p, scratch) in elements.iter().zip(scratch_space.iter_mut()) {
             *scratch = acc;
-            acc = F::conditional_select(&(acc * *p), &acc, p.ct_eq(&F::zero()));
+            acc = F::conditional_select(&(acc * *p), &acc, p.is_zero());
         }
         acc = acc.invert().unwrap();
         let allinv = acc;
 
         for (p, scratch) in elements.iter_mut().zip(scratch_space.iter()).rev() {
             let tmp = *scratch * acc;
-            let skip = p.ct_eq(&F::zero());
+            let skip = p.is_zero();
             acc = F::conditional_select(&(acc * *p), &acc, skip);
             *p = F::conditional_select(&tmp, &p, skip);
         }
@@ -109,11 +109,11 @@ impl BatchInverter {
         TE: Fn(&mut T) -> &mut F,
         TS: Fn(&mut T) -> &mut F,
     {
-        let mut acc = F::one();
+        let mut acc = F::ONE;
         for item in items.iter_mut() {
             *(scratch_space)(item) = acc;
             let p = (element)(item);
-            acc = F::conditional_select(&(acc * *p), &acc, p.ct_eq(&F::zero()));
+            acc = F::conditional_select(&(acc * *p), &acc, p.is_zero());
         }
         acc = acc.invert().unwrap();
         let allinv = acc;
@@ -121,7 +121,7 @@ impl BatchInverter {
         for item in items.iter_mut().rev() {
             let tmp = *(scratch_space)(item) * acc;
             let p = (element)(item);
-            let skip = p.ct_eq(&F::zero());
+            let skip = p.is_zero();
             acc = F::conditional_select(&(acc * *p), &acc, skip);
             *p = F::conditional_select(&tmp, &p, skip);
         }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -29,7 +29,7 @@ pub fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> C
     let mut b = x * w;
 
     // Initialize z as the 2^S root of unity.
-    let mut z = F::root_of_unity();
+    let mut z = F::ROOT_OF_UNITY;
 
     for max_v in (1..=F::S).rev() {
         let mut k = 1;
@@ -41,7 +41,7 @@ pub fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> C
         // - for k < j <= v, we square z in order to calculate ω.
         // - for j > v, we do nothing.
         for j in 2..max_v {
-            let b2k_is_one = b2k.ct_eq(&F::one());
+            let b2k_is_one = b2k.ct_eq(&F::ONE);
             let squared = F::conditional_select(&b2k, &z, b2k_is_one).square();
             b2k = F::conditional_select(&squared, &b2k, b2k_is_one);
             let new_z = F::conditional_select(&z, &squared, b2k_is_one);
@@ -51,7 +51,7 @@ pub fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> C
         }
 
         let result = x * z;
-        x = F::conditional_select(&result, &x, b.ct_eq(&F::one()));
+        x = F::conditional_select(&result, &x, b.ct_eq(&F::ONE));
         z = z.square();
         b *= z;
         v = k;
@@ -76,7 +76,7 @@ pub fn sqrt_tonelli_shanks<F: PrimeField, S: AsRef<[u64]>>(f: &F, tm1d2: S) -> C
 ///
 /// where $G_S$ is a non-square.
 ///
-/// For this method, $G_S$ is currently [`PrimeField::root_of_unity`], a generator of the
+/// For this method, $G_S$ is currently [`PrimeField::ROOT_OF_UNITY`], a generator of the
 /// order $2^S$ subgroup. Users of this crate should not rely on this generator being
 /// fixed; it may be changed in future crate versions to simplify the implementation of
 /// the SSWU hash-to-curve algorithm.
@@ -108,8 +108,8 @@ pub fn sqrt_ratio_generic<F: PrimeField>(num: &F, div: &F) -> (Choice, F) {
     // based on whether a is square, but for the boolean output we need to handle the
     // num != 0 && div == 0 case specifically.
 
-    let a = div.invert().unwrap_or_else(F::zero) * num;
-    let b = a * F::root_of_unity();
+    let a = div.invert().unwrap_or(F::ZERO) * num;
+    let b = a * F::ROOT_OF_UNITY;
     let sqrt_a = a.sqrt();
     let sqrt_b = b.sqrt();
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -41,7 +41,7 @@ mod full_limbs {
 fn batch_inversion() {
     use ff::{BatchInverter, Field};
 
-    let one = Bls381K12Scalar::one();
+    let one = Bls381K12Scalar::ONE;
 
     // [1, 2, 3, 4]
     let values: Vec<_> = (0..4)
@@ -55,7 +55,7 @@ fn batch_inversion() {
     // Test BatchInverter::invert_with_external_scratch
     {
         let mut elements = values.clone();
-        let mut scratch_space = vec![Bls381K12Scalar::zero(); elements.len()];
+        let mut scratch_space = vec![Bls381K12Scalar::ZERO; elements.len()];
         BatchInverter::invert_with_external_scratch(&mut elements, &mut scratch_space);
         for (a, a_inv) in values.iter().zip(elements.into_iter()) {
             assert_eq!(*a * a_inv, one);


### PR DESCRIPTION
We now require that the type implementing `Field`, and its particular values for these constants, can be constructed in a const context. Once upon a time this might have been onerous, but it should now be a reasonable requirement given our MSRV of 1.56.0.

Closes zkcrypto/ff#87.