### PR TITLE
Fix unnecessary as_mut()

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1282,7 +1282,7 @@ fn prime_field_impl(
                     // `0xfff... >> REPR_SHAVE_BITS` overflows. So use `checked_shr` instead.
                     // This is always sufficient because we will have at most one spare limb
                     // to accommodate values of up to twice the modulus.
-                    tmp.0.as_mut()[#top_limb_index] &= 0xffffffffffffffffu64.checked_shr(REPR_SHAVE_BITS).unwrap_or(0);
+                    tmp.0[#top_limb_index] &= 0xffffffffffffffffu64.checked_shr(REPR_SHAVE_BITS).unwrap_or(0);
 
                     if tmp.is_valid() {
                         return tmp


### PR DESCRIPTION
This `as_mut()` was causing type inference problems after I added an array crate (hybrid-array) to my rust-project using ff-derive. Removing it worked and made the macro compile again.