### PR TITLE
fix: typos in documentation files

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1381,7 +1381,7 @@ fn prime_field_impl(
             }
 
             /// Subtracts the modulus from this element if this element is not in the
-            /// field. Only used interally.
+            /// field. Only used internally.
             #[inline(always)]
             fn reduce(&mut self) {
                 if !self.is_valid() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub trait PrimeField: Field + From<u64> {
 pub trait WithSmallOrderMulGroup<const N: u8>: PrimeField {
     /// A field element of small multiplicative order $N$.
     ///
-    /// The presense of this element allows you to perform (certain types of)
+    /// The presence of this element allows you to perform (certain types of)
     /// endomorphisms on some elliptic curves.
     ///
     /// It can be calculated using [SageMath] as


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `interally` to `internally`
Corrected `presense` to `presence`

Please review the changes and let me know if any additional changes are needed.

