### PR TITLE
Fix/typ

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1381,7 +1381,7 @@ fn prime_field_impl(
             }
 
             /// Subtracts the modulus from this element if this element is not in the
-            /// field. Only used interally.
+            /// field. Only used internally.
             #[inline(always)]
             fn reduce(&mut self) {
                 if !self.is_valid() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub trait PrimeField: Field + From<u64> {
 pub trait WithSmallOrderMulGroup<const N: u8>: PrimeField {
     /// A field element of small multiplicative order $N$.
     ///
-    /// The presense of this element allows you to perform (certain types of)
+    /// The presence of this element allows you to perform (certain types of)
     /// endomorphisms on some elliptic curves.
     ///
     /// It can be calculated using [SageMath] as


### PR DESCRIPTION
# Fix: Corrected typos in Rust source files

## What was changed
1. **Corrected typos**:
   - Replaced `presense` with `presence` in `src/lib.rs:361`.
   - Replaced `interally` with `internally` in `ff_derive/src/lib.rs:1384`.

## Why these changes were made
- **Fixing typos** improves the clarity and professionalism of the codebase, ensuring accuracy and ease of understanding for developers.

## Additional Notes
- These changes focus solely on correcting typographical errors and do not affect the functionality of the code.
