### PR TITLE
Use `CryptoRng` instead of plain `RngCore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this library adheres to Rust's notion of
   trait object as the RNG.
 - `ff::Field::try_from_rng` is a new trait method that must be implemented by
   downstreams. `Field::random` now has a default implementation that calls it.
+- `ff::Field` now requires a CSPRNG (`CryptoRng`) instead of a plain RNG.
 
 ### Removed
 - `derive_bits` feature flag (use `bits` instead).

--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1267,7 +1267,7 @@ fn prime_field_impl(
             const ONE: Self = R;
 
             /// Computes a uniformly random element using rejection sampling.
-            fn try_from_rng<R: ::ff::derive::rand_core::TryRngCore + ?Sized>(rng: &mut R) -> ::core::result::Result<Self, R::Error> {
+            fn try_from_rng<R: ::ff::derive::rand_core::TryCryptoRng + ?Sized>(rng: &mut R) -> ::core::result::Result<Self, R::Error> {
                 loop {
                     let mut tmp = {
                         let mut repr = [0u64; #limbs];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use rand_core::{RngCore, TryRngCore};
+use rand_core::{CryptoRng, TryCryptoRng};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 /// Bit representation of a field element.
@@ -76,7 +76,7 @@ pub trait Field:
     const ONE: Self;
 
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self {
+    fn random<R: CryptoRng + ?Sized>(rng: &mut R) -> Self {
         Self::try_from_rng(rng)
             .map_err(|e: Infallible| e)
             .expect("Infallible failed")
@@ -88,7 +88,7 @@ pub trait Field:
     }
 
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn try_from_rng<R: TryRngCore + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
+    fn try_from_rng<R: TryCryptoRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
 
     /// Returns true iff this element is zero.
     fn is_zero(&self) -> Choice {


### PR DESCRIPTION
This is meant to fix this TODO:
https://github.com/RustCrypto/elliptic-curves/blob/f0ae3ae87dc935e563eb40be8c07fbbc53875270/k256/src/arithmetic/scalar.rs#L194