### PR TITLE
Have `PrimeField::from_repr` borrow its input

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1189,7 +1189,7 @@ fn prime_field_impl(
         impl ::ff::PrimeField for #name {
             type Repr = #repr;
 
-            fn from_repr(r: #repr) -> ::ff::derive::subtle::CtOption<#name> {
+            fn from_repr(r: &#repr) -> ::ff::derive::subtle::CtOption<#name> {
                 #from_repr_impl
 
                 // Try to subtract the modulus
@@ -1207,7 +1207,7 @@ fn prime_field_impl(
                 ::ff::derive::subtle::CtOption::new(r * &R2, is_some)
             }
 
-            fn from_repr_vartime(r: #repr) -> Option<#name> {
+            fn from_repr_vartime(r: &#repr) -> Option<#name> {
                 #from_repr_impl
 
                 if r.is_valid() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub trait PrimeField: Field + From<u64> {
     ///
     /// The byte representation is interpreted with the same endianness as elements
     /// returned by [`PrimeField::to_repr`].
-    fn from_repr(repr: Self::Repr) -> CtOption<Self>;
+    fn from_repr(repr: &Self::Repr) -> CtOption<Self>;
 
     /// Attempts to convert a byte representation of a field element into an element of
     /// this prime field, failing if the input is not canonical (is not smaller than the
@@ -293,7 +293,7 @@ pub trait PrimeField: Field + From<u64> {
     ///
     /// This method provides **no** constant-time guarantees. Implementors of the
     /// `PrimeField` trait **may** optimise this method using non-constant-time logic.
-    fn from_repr_vartime(repr: Self::Repr) -> Option<Self> {
+    fn from_repr_vartime(repr: &Self::Repr) -> Option<Self> {
         Self::from_repr(repr).into()
     }
 


### PR DESCRIPTION
From the API guidelines, a function that does not require ownership should borrow its input:

https://rust-lang.github.io/api-guidelines/flexibility.html?highlight=clone#caller-decides-where-to-copy-and-place-data-c-caller-control

In general, I think there's an intermediate decoding step between `PrimeField::Repr` and the corresponding `Self` type which receives an impl thereof, rather than the `Self` type actually taking ownership of the `Repr` data.

Since field element types sometimes represent secrets, taking ownership of the data means the caller can't zeroize that data, and moving the data rather than borrowing it may introduce an additional copy.