### PR TITLE
Rename `Field::try_from_rng` => `try_random`

### DIFF
--- a/ff_derive/src/lib.rs
+++ b/ff_derive/src/lib.rs
@@ -1259,7 +1259,7 @@ fn prime_field_impl(
             const ONE: Self = R;
 
             /// Computes a uniformly random element using rejection sampling.
-            fn try_from_rng<R: ::ff::derive::rand_core::TryRng + ?Sized>(rng: &mut R) -> ::core::result::Result<Self, R::Error> {
+            fn try_random<R: ::ff::derive::rand_core::TryRng + ?Sized>(rng: &mut R) -> ::core::result::Result<Self, R::Error> {
                 loop {
                     let mut tmp = {
                         let mut repr = [0u64; #limbs];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,12 +76,12 @@ pub trait Field:
 
     /// Returns an element chosen uniformly at random using a user-provided RNG.
     fn random<R: Rng + ?Sized>(rng: &mut R) -> Self {
-        let Ok(out) = Self::try_from_rng(rng);
+        let Ok(out) = Self::try_random(rng);
         out
     }
 
     /// Returns an element chosen uniformly at random using a user-provided RNG.
-    fn try_from_rng<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
+    fn try_random<R: TryRng + ?Sized>(rng: &mut R) -> Result<Self, R::Error>;
 
     /// Returns true iff this element is zero.
     fn is_zero(&self) -> Choice {

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -34,7 +34,7 @@ mod full_limbs {
         use getrandom::{rand_core::UnwrapErr, SysRng};
 
         let _ = F384p::random(&mut UnwrapErr(SysRng));
-        let _ = F384p::try_from_rng(&mut SysRng).unwrap();
+        let _ = F384p::try_random(&mut SysRng).unwrap();
     }
 }
 


### PR DESCRIPTION
Followup to #149, since the name has been changed in zkcrypto/rfcs#1