### PR TITLE
Little endianness serialization method 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,15 @@ pub trait PrimeField: Field + From<u64> {
     /// encodings of field elements should be treated as opaque.
     fn to_repr(&self) -> Self::Repr;
 
+    /// Converts an element of the prime field into a little-endian byte representation.
+    ///
+    /// The default implementation assumes [`Self::to_repr`] already returns a little-endian
+    /// encoding. Implementors whose [`Self::to_repr`] uses big-endian encoding must override
+    /// this method (e.g. by reversing the bytes).
+    fn to_le_repr(&self) -> Self::Repr {
+        self.to_repr()
+    }
+
     /// Returns true iff this element is odd.
     fn is_odd(&self) -> Choice;
 


### PR DESCRIPTION
References https://github.com/zkcrypto/ff/issues/155#issuecomment-4558006184 and pairs with https://github.com/zkcrypto/group/pull/81. Adds a second `to_le_repr` serialization on `PrimeField` as a provided trait method. 