### PR TITLE
Add derive coverage for big-endian field representations

### DIFF
--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -38,6 +38,26 @@ mod full_limbs {
     }
 }
 
+mod big_endian_repr {
+    #[derive(PrimeField)]
+    #[PrimeFieldModulus = "65537"]
+    #[PrimeFieldGenerator = "3"]
+    #[PrimeFieldReprEndianness = "big"]
+    struct Fp([u64; 1]);
+
+    #[test]
+    fn round_trips() {
+        use ff::PrimeField;
+
+        let element = Fp::from(0x1234);
+        let repr = element.to_repr();
+
+        assert_eq!(repr.0, [0, 0, 0, 0, 0, 0, 0x12, 0x34]);
+        assert_eq!(Fp::from_repr(repr).unwrap(), element);
+        assert_eq!(Fp::from_repr_vartime(repr), Some(element));
+    }
+}
+
 #[test]
 fn constants() {
     use ff::{Field, PrimeField};


### PR DESCRIPTION
This PR adds test coverage for `#[derive(PrimeField)]` when using
`#[PrimeFieldReprEndianness = "big"]`.

The existing derive tests exercise little-endian representations, but the derive
macro also supports big-endian representations. The new test defines a small
prime field, checks that `to_repr` emits the expected big-endian bytes, and
verifies that both `from_repr` and `from_repr_vartime` round-trip correctly.


I have test this change by executing:

- `cargo test --all-features`
- `cargo test --no-default-features --features derive`
- `cargo fmt -- --check`
